### PR TITLE
Removed maxlength for pw and changed maxlength for user_name to 255.

### DIFF
--- a/admin/default.page.htm
+++ b/admin/default.page.htm
@@ -145,11 +145,11 @@ between the start and end section tags are the only parts of the template that a
             <form id="fm-form" method="post" action="index.php?page=login" >
               <div class="row center">
                 <label for="user_name">Username:</label>
-                <input name="user_name" id="user_name" type="text" maxlength="20" size="15"/>
+                <input name="user_name" id="user_name" type="text" maxlength="255" size="15"/>
               </div>
               <div class="row">
                 <label for="pw">Password:</label>
-                <input name="pw" id="pw" type="password" maxlength="20" size="15"/><br />
+                <input name="pw" id="pw" type="password" size="15"/><br />
               </div>
               <div class="row">
                 <input value="Submit" type="submit" />


### PR DESCRIPTION
* user_name is defined in the database schema varchar(255). Why allow
  255 characters in the database when you can only enter 20 via the
  web interface?
* https://github.com/Program-O/Program-O/blob/master/install/new.sql#L120
* pw: Why limiting the length of the password to 20? There is a
  hash function used to map a input of variable length to a fix length
  output. Currently md5 is used which is broken and must never be used
  to store passwords. Also there is no salt being used.