### PR TITLE
Fixed session path generation in install script

### DIFF
--- a/install/install_programo.php
+++ b/install/install_programo.php
@@ -22,7 +22,7 @@
   $errorMessage .= $no_unicode_message;
   require_once ('install_config.php');
   $dirArray = glob(_ADMIN_PATH_ . "ses_*",GLOB_ONLYDIR);
-  $session_dir = (empty($dirArray)) ? 'ses_' . md5(time()) : $dirArray[0];
+  $session_dir = (empty($dirArray)) ? 'ses_' . md5(time()) : basename($dirArray[0]);
   $dupPS = "$path_separator$path_separator";
   $session_dir = str_replace($dupPS, $path_separator, $session_dir); // remove double path separators when necessary
   $writeCheckArray = array('config' => _CONF_PATH_, 'debug' => _DEBUG_PATH_, 'logs' => _LOG_PATH_);


### PR DESCRIPTION
The `glob()` function returns an array of pathnames relative to the current directory, but `$session_dir` is expected to be a simple filename at line 25.

This patch fixes the installation script by trimming the pathname using the `basename()` function.