### PR TITLE
Fixed bot creation through admin interface

### DIFF
--- a/admin/select_bots.php
+++ b/admin/select_bots.php
@@ -327,7 +327,7 @@ VALUES (NULL,:bot_name,:bot_desc,:bot_active,:bot_parent_id,:format,:save_state,
     ':debugemail'         => $debugemail,
     ':debugshow'          => $debugshow,
     ':debugmode'          => $debugmode,
-    ':aiml_pattern'       => $aiml_pattern,
+    ':aiml_pattern'       => $default_aiml_pattern,
     ':error_response'     => $error_response
   );
   $affectedRows = db_write($sql, $params, false, __FILE__, __FUNCTION__, __LINE__);

--- a/library/PDO_functions.php
+++ b/library/PDO_functions.php
@@ -130,7 +130,7 @@
     {
       $pdoError = print_r($dbConn->errorInfo(), true);
       $psError  = print_r($sth->errorInfo(), true);
-      error_log("bad SQL encountered in file $file, line #$line. SQL:\n$sql\nPDO Error:\n$pdoError\nSTH Error:\n$psError\nEsception Message:\n" . $e->getMessage(), 3, _LOG_PATH_ . 'db_write.txt');
+      error_log("bad SQL encountered in file $file, line #$line. SQL:\n$sql\nPDO Error:\n$pdoError\nSTH Error:\n$psError\nException Message:\n" . $e->getMessage() . "\n", 3, _LOG_PATH_ . 'db_write.txt');
       runDebug(__FILE__, __FUNCTION__, __LINE__, "An error was generated while writing to the database in file $file at line $line, in the function $function - SQL:\n$sql\nPDO error: $pdoError\nPDOStatement error: $psError", 0);
       return false;
     }


### PR DESCRIPTION
Bot creation through the admin interface would fail because of a mismatching POST parameter. The HTML page (at `/programo/admin/index.php?page=select_bots`) contains a `default_aiml_pattern` input element, whereas the script would expect a parameter named `aiml_pattern`.
The subsequent SQL command would fail because the relative DB column cannot be `NULL`.