### PR TITLE
Logical conditions on AIML pattern filtering SQL

### DIFF
--- a/chatbot/core/aiml/find_aiml.php
+++ b/chatbot/core/aiml/find_aiml.php
@@ -897,24 +897,24 @@
     {
     //if there is one word do this
       $sql = "SELECT `id`, `pattern`, `thatpattern`, `topic` FROM `$dbn`.`aiml` WHERE
-  $sql_bot_select AND
+  $sql_bot_select AND (
   `pattern` = '_' OR
   `pattern` = '*' OR
   `pattern` = '$lookingfor' OR
   `pattern` = '$default_aiml_pattern'
-   $topic_select order by `topic` desc, `id` asc, `pattern` asc;";
+  ) $topic_select order by `topic` desc, `id` asc, `pattern` asc;";
     }
     else
     {
     //otherwise do this
       $sql_add = make_like_pattern($lookingfor, 'pattern');
       $sql = "SELECT `id`, `bot_id`, `pattern`, `thatpattern`, `topic` FROM `$dbn`.`aiml` WHERE
-  $sql_bot_select AND
+  $sql_bot_select AND (
   `pattern` = '_' OR
   `pattern` = '*' OR
   `pattern` = '$lookingfor' OR $sql_add
   `pattern` = '$default_aiml_pattern'
-  $topic_select
+  ) $topic_select
   order by `topic` desc, `id` asc, `pattern` asc;";
     }
     runDebug(__FILE__, __FUNCTION__, __LINE__, "Match AIML sql: $sql", 3);

--- a/chatbot/core/aiml/find_aiml.php
+++ b/chatbot/core/aiml/find_aiml.php
@@ -887,7 +887,7 @@
     }
     if (!empty($storedtopic))
     {
-      $topic_select = "AND `topic`='' OR\n  `topic`='$storedtopic'";
+      $topic_select = "AND (`topic`='' OR `topic`='$storedtopic')";
     }
     else
     {


### PR DESCRIPTION
I might be misunderstanding how the program is intended to operate, however we noticed some errors in how AIML patterns are fetched from the DB.

In particular, on some user queries, Program-O would answer with patterns from other bots (which is particularly noticeable because we installed bots in different languages).
Also, there were some inconsistencies when working with conversation topics.

Before the submitted changes, the SQL query fetching AIML patterns had the following form:
```sql
SELECT `id`, `bot_id`, `pattern`, `thatpattern`, `topic` FROM `$dbn`.`aiml` WHERE
  bot_id = '$bot_id' AND
  `pattern` = '_' OR
  `pattern` = '*' OR
  `pattern` = '$lookingfor'
  `pattern` = '$default_aiml_pattern'
  AND `topic`='' OR `topic`='$storedtopic'
  order by `topic` desc, `id` asc, `pattern` asc;";
```

Notice that, because of operator precedence and associativity rules, the bot filtering rule is applied only in combination with the first `'_'` pattern. Same goes for the topic filtering clause.
That is, the final logical condition looks more or less like this:

```
SELECT (bot filter AND '_') OR '*' OR '$lookingfor' OR ('$default_aiml_pattern' AND void topic) OR storedtopic
```

The changes submitted reform the SQL query to this form:

```
SELECT bot filter AND ('_' OR '*' OR '$lookingfor' OR '$default_aiml_pattern') AND (void topic OR storedtopic)
```