### PR TITLE
Topic is correctly set to empty for AIML patterns outside of a topic

### DIFF
--- a/admin/upload.php
+++ b/admin/upload.php
@@ -221,7 +221,7 @@ endScript;
             ':pattern' => $pattern,
             ':that' => $that,
             ':template' => $template,
-            ':topic' => $topic,
+            ':topic' => '',
             ':fileName' => $fileName
           );
         }


### PR DESCRIPTION
Because of how PHP [does *not* create scoping](https://secure.phabricator.com/book/phabflavor/article/php_pitfalls/#foreach-does-not-create) in `foreach` loops, the `topic` variable is retained even for AIML patterns outside of a topic.

In this example:
```xml
<topic name="something">
	<category>
		<pattern>question on topic</pattern>
	</category>
</topic>
<category>
	<pattern>generic question</pattern>
</category>
```
the `generic question` pattern would be assigned to the `something` topic in the DB.