### PR TITLE
Fix condition tag match check

### DIFF
--- a/chatbot/core/aiml/parse_aiml_as_XML.php
+++ b/chatbot/core/aiml/parse_aiml_as_XML.php
@@ -742,7 +742,7 @@
           $testVarValue = (isset($attr['value'])) ? (string)$attr['value'] : '';
           runDebug(__FILE__, __FUNCTION__, __LINE__,"Pick Value = '$testVarValue'", 4);
           runDebug(__FILE__, __FUNCTION__, __LINE__,"Checking to see if $testVarValue (condition value) is equal to $test_value (Client Property).", 4);
-          if (strtolower($testVarValue) == strtolower($test_value))
+          if (_strtolower($testVarValue) == _strtolower($test_value))
           {
             runDebug(__FILE__, __FUNCTION__, __LINE__,'Pick XML = ' . $pick->asXML(), 4);
             break;

--- a/library/misc_functions.php
+++ b/library/misc_functions.php
@@ -18,7 +18,6 @@
    * @param array $params
    * @return mixed|string (string) $out - The returned value from the curl_exec() call.
    */
-
   function get_cURL($url, $options = array(), $params = array())
   {
     $failed = 'Cannot process CURL call.'; // This will need to be changed, at some point.
@@ -42,6 +41,30 @@
       return $data;
     }
     else return $failed;
+  }
+
+  /**
+   * function _strtolower
+   * Performs multibyte or standard lowercase conversion of a string,
+   * based on configuration.
+   *
+   * @param string $text The string to convert.
+   * @return string The input string converted to lower case.
+   */
+  function _strtolower($text) {
+    return (IS_MB_ENABLED) ? mb_strtolower($text) : strtolower($text);
+  }
+
+  /**
+   * function _strtoupper
+   * Performs multibyte or standard uppercase conversion of a string,
+   * based on configuration.
+   *
+   * @param string $text The string to convert.
+   * @return string The string converted to upper case.
+   */
+  function _strtoupper($text) {
+    return (IS_MB_ENABLED) ? mb_strtoupper($text) : strtoupper($text);
   }
 
   /**


### PR DESCRIPTION
Check for matches in `<CONDITION>` tags now works with multibyte characters as well.

Found this bug when working with values using accented letters, where the match would fail even if the accented letter is correctly stored. Like:
```xml
<condition name="giorno">
    <li value="lunedì">Inizio settimana.</li>
    <li value="martedì">Martedì.</li>
    <li>Altro.</li>
</condition>
```

I also added two shared functions `_strtolower` and `_strtoupper` which can be used to replace the very common construct `(IS_MB_ENABLED) ? mb_strtolower(...) : strtolower(...)` used throughout the code base.