### PR TITLE
Support for simple pattern expressions in condition tags

### DIFF
--- a/chatbot/core/aiml/find_aiml.php
+++ b/chatbot/core/aiml/find_aiml.php
@@ -287,6 +287,22 @@
   }
 
   /**
+   * Performs a pattern matching pass on an input string, checking
+   * whether it matches a given pattern based on the AIML specification.
+   *
+   * @param string $pattern Pattern to match.
+   * @param string $input Input string to check.
+   * @return bool True if the string matches the pattern, false otherwise.
+   **/
+  function aiml_pattern_match($pattern, $input) {
+    if(empty($input))
+      return false;
+
+    $pattern_regex = build_wildcard_RegEx(_strtolower($pattern));
+    return preg_match($pattern_regex, _strtolower($input)) === 1;
+  }
+
+  /**
    * Takes all the relevant sql results and scores them to find the most likely match with the aiml
    *
    * @param array  $convoArr

--- a/chatbot/core/aiml/find_aiml.php
+++ b/chatbot/core/aiml/find_aiml.php
@@ -137,7 +137,7 @@
   function unset_all_bad_pattern_matches($convoArr, $allrows, $lookingfor)
   {
     global $error_response;
-    $lookingfor_lc = make_lc($lookingfor);
+    $lookingfor_lc = _strtolower($lookingfor);
     $current_topic = get_topic($convoArr);
     $current_thatpattern = (isset ($convoArr['that'][1][1])) ? $convoArr['that'][1][1] : '';
     //file_put_contents(_LOG_PATH_ . 'allrows.txt', print_r($allrows, true));
@@ -163,17 +163,17 @@
     foreach ($allrows as $all => $subrow)
     {
       //get the pattern
-      $aiml_pattern = make_lc($subrow['pattern']);
+      $aiml_pattern = _strtolower($subrow['pattern']);
       $aiml_pattern_wildcards = build_wildcard_RegEx($aiml_pattern);
-      $default_pattern_lc = make_lc($default_pattern);
+      $default_pattern_lc = _strtolower($default_pattern);
 
       //get the that pattern
-      $aiml_thatpattern = make_lc($subrow['thatpattern']);
-      $current_thatpattern = make_lc($current_thatpattern);
+      $aiml_thatpattern = _strtolower($subrow['thatpattern']);
+      $current_thatpattern = _strtolower($current_thatpattern);
       //get topic pattern
       $topicMatch = FALSE;
-      $aiml_topic = make_lc(trim($subrow['topic']));
-      $current_topic_lc = make_lc($current_topic);
+      $aiml_topic = _strtolower(trim($subrow['topic']));
+      $current_topic_lc = _strtolower($current_topic);
 
       #Check for a matching topic
       $aiml_topic_wildcards = (!empty($aiml_topic)) ? build_wildcard_RegEx($aiml_topic) : '';
@@ -343,13 +343,13 @@
       $check_pattern_words  = true;
 
       # make it all lower case, to make it easier to test, and do it using mbstring functions if possible
-      $category_pattern_lc     = make_lc($category_pattern);
-      $category_thatpattern_lc = make_lc($category_thatpattern);
-      $category_topic_lc       = make_lc($category_topic);
-      $default_pattern_lc      = make_lc($default_pattern);
-      $pattern_lc              = make_lc($pattern);
-      $topic_lc                = make_lc($topic);
-      $that_lc                 = make_lc($that);
+      $category_pattern_lc     = _strtolower($category_pattern);
+      $category_thatpattern_lc = _strtolower($category_thatpattern);
+      $category_topic_lc       = _strtolower($category_topic);
+      $default_pattern_lc      = _strtolower($default_pattern);
+      $pattern_lc              = _strtolower($pattern);
+      $topic_lc                = _strtolower($topic);
+      $that_lc                 = _strtolower($that);
 
       // Start scoring here
       $current_score = 0;
@@ -450,7 +450,7 @@
               $track_matches .= 'thatpattern match with star, ';
             }
         }
-        
+
         #3d.) no match at all
         else {
           $current_score = $rejected;
@@ -510,8 +510,8 @@
       if ($check_pattern_words && $category_pattern_lc != $default_pattern_lc)
       {
         # 5a.) first, a little setup
-        $pattern_lc = make_lc($pattern);
-        $category_pattern_lc = make_lc($category_pattern);
+        $pattern_lc = _strtolower($pattern);
+        $category_pattern_lc = _strtolower($category_pattern);
         $pattern_words = explode(" ", $pattern_lc);
 
         # 5b.) break the input pattern into an array of individual words and iterate through the array
@@ -1034,9 +1034,3 @@
     $retval = ($num_rows == 0) ? '' : $row['value'];
     return $retval;
   }
-
-  function make_lc($txt)
-  {
-    return (IS_MB_ENABLED) ? mb_strtolower($txt) : strtolower($txt);
-  }
-

--- a/chatbot/core/aiml/parse_aiml_as_XML.php
+++ b/chatbot/core/aiml/parse_aiml_as_XML.php
@@ -741,8 +741,8 @@
           runDebug(__FILE__, __FUNCTION__, __LINE__,'Current pick attributes = ' . print_r($attr, true), 4);
           $testVarValue = (isset($attr['value'])) ? (string)$attr['value'] : '';
           runDebug(__FILE__, __FUNCTION__, __LINE__,"Pick Value = '$testVarValue'", 4);
-          runDebug(__FILE__, __FUNCTION__, __LINE__,"Checking to see if $testVarValue (condition value) is equal to $test_value (Client Property).", 4);
-          if (_strtolower($testVarValue) == _strtolower($test_value))
+          runDebug(__FILE__, __FUNCTION__, __LINE__,"Checking to see if $test_value (Client Property) matches $testVarValue (condition value).", 4);
+          if (aiml_pattern_match($testVarValue, $test_value))
           {
             runDebug(__FILE__, __FUNCTION__, __LINE__,'Pick XML = ' . $pick->asXML(), 4);
             break;


### PR DESCRIPTION
As described in the [AIML spec 1.0.1](http://www.alicebot.org/TR/2005/WD-aiml/#section-condition) (and [partially discussed here](https://www.chatbots.org/ai_zone/viewthread/1858/)), `<condition>` tags can contain simple pattern expressions in their `value` attributes.

These changes add a generic `aiml_pattern_match` function to perform AIML simple pattern matching (which relies on the regex implementation already present) and uses it in the `parse_condition_tag` function. (Also, some redundant code has been cleaned up.)

Example AIML code, with obvious GoT references, like:
```xml
<category>
    <pattern>WHO AM I</pattern>
    <template>
        <condition name="name">
            <li value="* Snow"><get name="name" />, bastard from the North.</li>
            <li value="*">Your name is <get name="name" />.</li>
            <li>No idea.</li>
        </condition>
    </template>
</category>
```
now works as intended if your `name` variable is set to "Jon Snow".