### PR TITLE
strtoupper method bug in find_aiml_matches.

### DIFF
--- a/chatbot/core/aiml/find_aiml.php
+++ b/chatbot/core/aiml/find_aiml.php
@@ -973,7 +973,7 @@ function find_aiml_matches($convoArr)
 
     #$lookingfor = get_convo_var($convoArr,"aiml","lookingfor");
     $convoArr['aiml']['lookingfor'] = str_replace('  ', ' ', $convoArr['aiml']['lookingfor']);
-    $lookingfor = trim(strtoupper($convoArr['aiml']['lookingfor']));
+    $lookingfor = trim(mb_strtoupper($convoArr['aiml']['lookingfor']));
 
     //get the first and last words of the cleaned user input
     $lastInputWord = get_last_word($lookingfor);


### PR DESCRIPTION
use mb_strtoupper instead of strtoupper in find_aiml_matches method for it may cause problem of the "lookingfor" variable when it is a multi-byte one.