### PR TITLE
Update to improve error message.

### DIFF
--- a/install/install_programo.php
+++ b/install/install_programo.php
@@ -56,7 +56,7 @@ foreach ($writeCheckArray as $key => $folder)
             error_log("The folder $folder is not writable. Folder exists?: $dirExists. Permissions: $txtPerms." . PHP_EOL, 3, '../logs/install.log');
 
             $errFlag = true;
-            $errorMessage .= "<p class=\"red bold\">The $key folder cannot be written to, or does not exist. Please correct this before you continue.</p>";
+            $errorMessage .= "<p class=\"red bold\">The $key folder located here: $folder cannot be written to, or does not exist. Please correct this before you continue.</p>";
         }
         else
         {


### PR DESCRIPTION
I was trying to install, had folders without correct security. One was the debug folder. I assumed it was located with the other two, I couldn't locate it. So the error now tells there user where the folder is located so they know exactly where to go in order to correct the folder security.